### PR TITLE
Provide nginx if [ -d ".nginx-conf" ]

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -188,6 +188,9 @@ bpwatch start pylibmc_install
   source $BIN_DIR/steps/pylibmc
 bpwatch stop pylibmc_install
 
+# Install nginx if required by user
+source $BIN_DIR/steps/nginx
+
 # Install Mercurial if it appears to be required.
 if (grep -Fiq "hg+" requirements.txt) then
   bpwatch start mercurial_install

--- a/bin/steps/nginx
+++ b/bin/steps/nginx
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+readonly nginx_version="1.6.2"
+
+readonly nginx_url="http://nginx.org/download/nginx-${nginx_version}.tar.gz"
+readonly nginx_sig="http://nginx.org/download/nginx-${nginx_version}.tar.gz.asc"
+
+source "${BIN_DIR}/utils"
+
+
+if [[ ! -d ".nginx-conf" ]]; then
+  exit 0 # nothing to do
+fi
+
+if [[ ! -f "${CACHE_DIR}/nginx-${nginx_version}/objs/nginx" ]]; then
+  puts-step "Downloading nginx"
+  mkdir -p "${CACHE_DIR}"
+
+  wget -q -P "${CACHE_DIR}" $nginx_url
+  wget -q -P "${CACHE_DIR}" $nginx_sig
+
+  puts-step "Checking signature"
+
+  # Import Maxim Dounin’s PGP public key
+  # http://nginx.org/en/pgp_keys.html
+  gpg -q --keyserver pgp.mit.edu --recv-keys A1C052F8 | indent
+  gpg -q --verify "${CACHE_DIR}/nginx-${nginx_version}.tar.gz.asc" \
+    "${CACHE_DIR}/nginx-${nginx_version}.tar.gz" | indent
+
+  tar xf "${CACHE_DIR}/nginx-${nginx_version}.tar.gz" -C "${CACHE_DIR}"
+
+  puts-step "Building nginx"
+
+  pushd "${CACHE_DIR}/nginx-${nginx_version}" >/dev/null
+
+  {
+    ./configure --prefix="/srv/www/.nginx"
+    make
+  } | indent
+else
+  pushd "${CACHE_DIR}/nginx-${nginx_version}" >/dev/null
+fi
+
+puts-step "Copying files"
+
+make install >/dev/null | indent
+
+popd >/dev/null
+
+puts-step "Preparing environment"
+
+mkdir -p "${BUILD_DIR}/.profile.d"
+echo "export PATH=\"\$HOME/.nginx/sbin:\$PATH\"" \
+  >"${BUILD_DIR}/.profile.d/nginx.sh"
+
+cp -R "/srv/www/.nginx" "${BUILD_DIR}"
+cp "${ROOT_DIR}/share/nginx.conf" "${BUILD_DIR}/.nginx/conf"
+cp "${ROOT_DIR}/share/start-nginx" "${BUILD_DIR}"

--- a/share/nginx.conf
+++ b/share/nginx.conf
@@ -1,0 +1,35 @@
+daemon off;
+worker_processes 1;
+
+error_log stderr warn;
+
+events {
+    worker_connections 256;
+}
+
+http {
+    include mime.types;
+    default_type  application/octet-stream;
+
+    sendfile on;
+
+    keepalive_timeout 65;
+
+    access_log off;
+
+    root /srv/www;
+
+    server {
+        listen $PORT default;
+        server_name localhost;
+
+        error_page 500 502 503 504 /50x.html;
+        location = /50x.html {
+            root html;
+        }
+
+        location / {
+            include /srv/www/.nginx-conf/*.conf;
+	}
+    }
+}

--- a/share/start-nginx
+++ b/share/start-nginx
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+if [[ -z "${PORT}" ]]; then
+  echo "fatal: \$PORT not set" >&2
+  exit 1
+fi
+sed -i.orig "s/\$PORT/${PORT}/g" .nginx/conf/nginx.conf
+nginx


### PR DESCRIPTION
Currently users are supposed to run their own HTTP WSGI server for
their Python application and they have to use this application if they
also want to serve static files or similar.

By creating the ".nginx-conf" directory, users now can trigger a build
of nginx. This allows them to create more advanced setups with different
locations, redirects, etc.