### PR TITLE
Bump default python version to 2.7.8

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ LEGACY_TRIGGER="lib/python2.7"
 PROFILE_PATH="$BUILD_DIR/.profile.d/python.sh"
 
 # Python version. This will be used in the future to specify custom Pythons.
-DEFAULT_PYTHON_VERSION="python-2.7.3"
+DEFAULT_PYTHON_VERSION="python-2.7.8"
 PYTHON_EXE="$APP_PYTHON_HOME_DIR/bin/python"
 PIP_VERSION="1.3.1"
 DISTRIBUTE_VERSION="0.6.36"


### PR DESCRIPTION
gevent and several depending projects still have issues with 2.7.9 due to the backported SSL changes from py3 (https://github.com/gevent/gevent/issues/477).